### PR TITLE
merge

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 const port = 3000;
 
@@ -8,42 +9,82 @@ app.use(express.json());
 // Enable CORS for frontend development
 app.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, x-api-key");
   next();
 });
 
-// Mock Data Contract
-let mockData = {
-  "status": "connected",
-  "read_interval_ms": 1000,
-  "data": {
-    "rpm": 0,
-    "temp_celsius": 90,
-    "fuel_liters": 45.0,
-    "speed_kmh": 0
-  },
-  "simulation_mode": true
+// API key middleware for /api/* routes
+app.use('/api', (req, res, next) => {
+  const apiKey = req.headers['x-api-key'];
+  if (apiKey !== 'csh-secure-v1') {
+    return res.status(401).json({ error: 'Unauthorized: missing or invalid x-api-key header' });
+  }
+  next();
+});
+
+// Simulation state with realistic incremental changes
+let simState = {
+  rpm: 900,
+  temperature: 78,
+  fuel_liters: 45.0,
+  speed_kmh: 0,
 };
 
-// Update RPM randomly to simulate live data
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function randomInRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+// Update simulation values with smooth incremental changes
 setInterval(() => {
-  if (mockData.data.rpm < 6000) {
-    mockData.data.rpm += Math.floor(Math.random() * 100);
-  } else {
-    mockData.data.rpm = 800; // Reset after peak
-  }
+  simState.rpm = clamp(
+    Math.round(simState.rpm + randomInRange(-150, 150)),
+    700, 4500
+  );
+  simState.temperature = clamp(
+    Math.round(simState.temperature + randomInRange(-1, 1)),
+    65, 110
+  );
+  simState.fuel_liters = clamp(
+    Number((simState.fuel_liters + randomInRange(-0.1, 0.05)).toFixed(1)),
+    1, 55
+  );
+  simState.speed_kmh = clamp(
+    Math.round(simState.speed_kmh + randomInRange(-5, 5)),
+    0, 180
+  );
 }, 1000);
 
 // API Endpoints
 app.get('/api/live', (req, res) => {
-  res.json(mockData);
+  res.json({
+    rpm: simState.rpm,
+    temperature: simState.temperature,
+    fuel_liters: simState.fuel_liters,
+    speed_kmh: simState.speed_kmh,
+    connected: false,
+    read_interval_ms: 1000,
+    mode: "simulator",
+    timestamp: new Date().toISOString(),
+  });
 });
 
 app.get('/api/status', (req, res) => {
   res.json({ backend: "OK", bus: "SIMULATED" });
 });
 
+app.get('/api/recordings', (req, res) => {
+  res.json({ recordings: [] });
+});
+
+// Serve client files (after API routes so API paths take priority)
+app.use(express.static(path.join(__dirname, '..', 'client')));
+
 app.listen(port, () => {
   console.log(`Backend listening at http://localhost:${port}`);
+  console.log(`Dashboard: http://localhost:${port}`);
   console.log(`Live data: http://localhost:${port}/api/live`);
 });

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,805 @@
+const pageTitleEl = document.querySelector("#page-title");
+const pageSubtitleEl = document.querySelector("#page-subtitle");
+const statusBannerEl = document.querySelector("#status-banner");
+const viewEl = document.querySelector("#view");
+
+const PAGE_META = {
+  "/": {
+    title: "Dashboard",
+    subtitle: "Live values, connection status and polling interval",
+  },
+  "/recordings": {
+    title: "Recordings",
+    subtitle: "Stored sessions with metadata",
+  },
+  "/recordings/:id": {
+    title: "Replay",
+    subtitle: "View recording and control replay",
+  },
+  "/settings": {
+    title: "Settings",
+    subtitle: "Manage polling, interface and logging",
+  },
+};
+
+const state = {
+  route: { path: "/", params: {} },
+  api: {
+    backendReachable: null,
+    liveFailures: 0,
+    recordingsFailures: 0,
+  },
+  liveData: null,
+  recordings: [],
+  lastLiveUpdate: null,
+  settings: {
+    pollIntervalMs: 1000,
+    interface: "simulator",
+    logging: true,
+  },
+  replay: {
+    selectedRecordingId: null,
+    playing: false,
+    progressPercent: 0,
+    timerId: null,
+    seriesCache: {},
+  },
+  timers: {
+    livePollingId: null,
+    recordingsPollingId: null,
+    activeLiveIntervalMs: null,
+  },
+};
+
+// --- Persistence helpers ---
+
+function saveState(key, obj) {
+  try {
+    localStorage.setItem(key, JSON.stringify(obj));
+  } catch (_) {
+    // storage full or unavailable
+  }
+}
+
+function loadState(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+// --- Event listeners ---
+
+window.addEventListener("hashchange", onRouteChange);
+viewEl.addEventListener("click", onViewClick);
+viewEl.addEventListener("submit", onViewSubmit);
+
+init();
+
+function init() {
+  // Restore persisted settings
+  const savedSettings = loadState("csh-settings");
+  if (savedSettings) {
+    state.settings.pollIntervalMs = normalizeInterval(savedSettings.pollIntervalMs || 1000);
+    state.settings.interface = savedSettings.interface || "simulator";
+    state.settings.logging = savedSettings.logging !== false;
+  }
+
+  // Restore persisted route
+  const savedRoute = loadState("csh-route");
+  if (!window.location.hash && savedRoute) {
+    window.location.hash = savedRoute;
+  } else if (!window.location.hash) {
+    window.location.hash = "#/";
+  }
+
+  onRouteChange();
+
+  // Restore replay state if navigating to replay
+  if (state.route.path === "/recordings/:id") {
+    const savedReplay = loadState("csh-replay");
+    if (savedReplay) {
+      state.replay.selectedRecordingId = savedReplay.selectedRecordingId || state.route.params.id;
+      state.replay.progressPercent = savedReplay.progressPercent || 0;
+    }
+  }
+
+  refreshLiveData();
+  refreshRecordings();
+  ensureLivePolling(state.settings.pollIntervalMs);
+  startRecordingsPolling();
+}
+
+function onRouteChange() {
+  state.route = parseRoute(window.location.hash);
+  if (state.route.path !== "/recordings/:id") {
+    stopReplayTimer();
+  } else {
+    state.replay.selectedRecordingId = state.route.params.id;
+  }
+  saveState("csh-route", window.location.hash);
+  render();
+}
+
+function parseRoute(hashValue) {
+  const hashWithoutMarker = (hashValue || "#/").replace(/^#/, "") || "/";
+  const [path] = hashWithoutMarker.split("?");
+  if (path === "/" || path === "") return { path: "/", params: {} };
+  if (path === "/recordings") return { path: "/recordings", params: {} };
+  if (path.startsWith("/recordings/")) {
+    const id = decodeURIComponent(path.split("/")[2] || "");
+    return { path: "/recordings/:id", params: { id } };
+  }
+  if (path === "/settings") return { path: "/settings", params: {} };
+  return { path: "/", params: {} };
+}
+
+function render() {
+  const meta = PAGE_META[state.route.path] || PAGE_META["/"];
+  pageTitleEl.textContent = meta.title;
+  pageSubtitleEl.textContent = meta.subtitle;
+  highlightActiveNav();
+  renderStatusBanner();
+  renderRouteContent();
+}
+
+function highlightActiveNav() {
+  const navLinks = document.querySelectorAll("[data-nav]");
+  navLinks.forEach((link) => {
+    const linkRoute = link.getAttribute("data-nav");
+    const isActive =
+      linkRoute === state.route.path ||
+      (linkRoute === "/recordings/:id" && state.route.path === "/recordings/:id");
+    link.classList.toggle("active", isActive);
+  });
+}
+
+function renderStatusBanner() {
+  const banner = resolveBannerData();
+  statusBannerEl.className = `status-banner ${banner.kind}`;
+  statusBannerEl.textContent = banner.message;
+}
+
+function resolveBannerData() {
+  if (!state.liveData && state.api.backendReachable === null) {
+    return { kind: "waiting", message: "Waiting for first data from backend..." };
+  }
+  if (state.api.backendReachable === false) {
+    return {
+      kind: "warning",
+      message: "Backend not reachable \u2013 client is showing simulated data.",
+    };
+  }
+  if (!state.liveData) {
+    return {
+      kind: "error",
+      message: "No live data available.",
+    };
+  }
+  if (state.liveData.connected) {
+    return {
+      kind: "ok",
+      message: `Connected (${state.liveData.mode || "hardware"}) \u00b7 Polling ${formatMs(
+        state.liveData.read_interval_ms
+      )}`,
+    };
+  }
+  return {
+    kind: "warning",
+    message: `No vehicle connection \u00b7 Mode: ${state.liveData.mode || "simulator"} \u00b7 Polling ${formatMs(
+      state.liveData.read_interval_ms
+    )}`,
+  };
+}
+
+function renderRouteContent() {
+  if (state.route.path === "/") {
+    viewEl.innerHTML = renderDashboardView();
+    return;
+  }
+  if (state.route.path === "/recordings") {
+    viewEl.innerHTML = renderRecordingsView();
+    return;
+  }
+  if (state.route.path === "/recordings/:id") {
+    viewEl.innerHTML = renderReplayView(state.route.params.id);
+    return;
+  }
+  if (state.route.path === "/settings") {
+    viewEl.innerHTML = renderSettingsView();
+    return;
+  }
+  viewEl.innerHTML = "";
+}
+
+function renderDashboardView() {
+  const live = state.liveData || {};
+  const connectionLabel = state.api.backendReachable
+    ? live.connected
+      ? "Connected"
+      : "Disconnected"
+    : "Simulation";
+
+  return `
+    <section class="grid-3">
+      <article class="card">
+        <p class="kpi-label">Engine RPM</p>
+        <p class="kpi-value">${formatNumber(live.rpm)}</p>
+        <p class="subtle">RPM</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Engine Temperature</p>
+        <p class="kpi-value">${formatNumber(live.temperature)}</p>
+        <p class="subtle">\u00b0C</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Fuel Level</p>
+        <p class="kpi-value">${formatDecimal(live.fuel_liters)}</p>
+        <p class="subtle">Liters</p>
+      </article>
+    </section>
+    <article class="card">
+      <p class="kpi-label">Status</p>
+      <p class="kpi-value">${escapeHtml(connectionLabel)}</p>
+      <p class="subtle">
+        Last update: ${formatDateTime(state.lastLiveUpdate)} \u00b7
+        Polling: ${formatMs(live.read_interval_ms || state.settings.pollIntervalMs)}
+      </p>
+    </article>
+  `;
+}
+
+function renderRecordingsView() {
+  if (!state.recordings.length) {
+    return `
+      <article class="empty-state">
+        No recordings found yet.
+      </article>
+    `;
+  }
+
+  const rows = state.recordings
+    .map(
+      (recording) => `
+      <tr>
+        <td>${escapeHtml(recording.name)}</td>
+        <td>${formatDateTime(recording.finished_at)}</td>
+        <td>${formatBytes(recording.size_bytes)}</td>
+        <td class="button-row">
+          <button data-action="open-recording" data-recording-id="${escapeHtml(
+            recording.id
+          )}">Open</button>
+          <button data-action="export-recording" data-recording-id="${escapeHtml(
+            recording.id
+          )}">Export JSON</button>
+        </td>
+      </tr>
+    `
+    )
+    .join("");
+
+  return `
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Finished</th>
+            <th>Size</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderReplayView(recordingId) {
+  const recording = state.recordings.find((item) => item.id === recordingId);
+  if (!recording) {
+    return `
+      <article class="empty-state">
+        Recording not found. Please select one from the recordings list first.
+      </article>
+      <div class="button-row">
+        <button data-action="go-recordings">Back to list</button>
+      </div>
+    `;
+  }
+
+  const points = getReplaySeries(recording.id);
+  const index = Math.min(
+    points.length - 1,
+    Math.floor((state.replay.progressPercent / 100) * (points.length - 1))
+  );
+  const currentPoint = points[index] || {};
+
+  return `
+    <article class="card">
+      <p class="kpi-label">Recording</p>
+      <p class="kpi-value">${escapeHtml(recording.name)}</p>
+      <p class="subtle">
+        ${formatDateTime(recording.finished_at)} \u00b7 ${formatBytes(recording.size_bytes)}
+      </p>
+    </article>
+    <article class="card">
+      <p class="kpi-label">Replay Progress</p>
+      <div class="progress">
+        <div style="width: ${state.replay.progressPercent}%"></div>
+      </div>
+      <p class="subtle">${state.replay.progressPercent.toFixed(0)}%</p>
+      <div class="button-row">
+        <button class="primary" data-action="toggle-replay">
+          ${state.replay.playing ? "Pause" : "Play"}
+        </button>
+        <button data-action="reset-replay">Reset</button>
+        <button data-action="go-recordings">Back to list</button>
+      </div>
+    </article>
+    <section class="grid-3">
+      <article class="card">
+        <p class="kpi-label">Replay RPM</p>
+        <p class="kpi-value">${formatNumber(currentPoint.rpm)}</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Replay Temperature</p>
+        <p class="kpi-value">${formatNumber(currentPoint.temperature)} \u00b0C</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Replay Fuel</p>
+        <p class="kpi-value">${formatDecimal(currentPoint.fuel_liters)} L</p>
+      </article>
+    </section>
+  `;
+}
+
+function renderSettingsView() {
+  return `
+    <article class="card">
+      <form id="settings-form" class="form-grid">
+        <label>
+          Polling Interval (ms)
+          <input name="pollIntervalMs" type="number" min="250" max="10000" step="50" value="${state.settings.pollIntervalMs}" />
+        </label>
+        <label>
+          Interface
+          <select name="interfaceMode">
+            <option value="simulator" ${
+              state.settings.interface === "simulator" ? "selected" : ""
+            }>simulator</option>
+            <option value="hardware" ${
+              state.settings.interface === "hardware" ? "selected" : ""
+            }>hardware</option>
+          </select>
+        </label>
+        <label>
+          Logging
+          <select name="logging">
+            <option value="true" ${state.settings.logging ? "selected" : ""}>enabled</option>
+            <option value="false" ${!state.settings.logging ? "selected" : ""}>disabled</option>
+          </select>
+        </label>
+        <div class="button-row">
+          <button class="primary" type="submit">Apply Settings</button>
+          <button type="button" data-action="refresh-now">Refresh Data Now</button>
+        </div>
+      </form>
+      <p class="subtle">
+        The client uses: <code>GET /api/live</code> and <code>GET /api/recordings</code>.
+        If these endpoints are unavailable, simulation mode activates automatically.
+      </p>
+    </article>
+  `;
+}
+
+function onViewClick(event) {
+  const target = event.target.closest("[data-action]");
+  if (!target) return;
+  const action = target.getAttribute("data-action");
+
+  if (action === "open-recording") {
+    const recordingId = target.getAttribute("data-recording-id");
+    if (recordingId) {
+      window.location.hash = `#/recordings/${encodeURIComponent(recordingId)}`;
+    }
+    return;
+  }
+
+  if (action === "export-recording") {
+    const recordingId = target.getAttribute("data-recording-id");
+    if (recordingId) {
+      exportRecording(recordingId);
+    }
+    return;
+  }
+
+  if (action === "toggle-replay") {
+    toggleReplay();
+    render();
+    return;
+  }
+
+  if (action === "reset-replay") {
+    stopReplayTimer();
+    state.replay.progressPercent = 0;
+    saveState("csh-replay", {
+      selectedRecordingId: state.replay.selectedRecordingId,
+      progressPercent: 0,
+    });
+    render();
+    return;
+  }
+
+  if (action === "go-recordings") {
+    window.location.hash = "#/recordings";
+    return;
+  }
+
+  if (action === "refresh-now") {
+    refreshLiveData();
+    refreshRecordings();
+  }
+}
+
+function onViewSubmit(event) {
+  const form = event.target;
+  if (!(form instanceof HTMLFormElement)) return;
+  if (form.id !== "settings-form") return;
+
+  event.preventDefault();
+  const formData = new FormData(form);
+
+  const nextInterval = normalizeInterval(
+    Number(formData.get("pollIntervalMs")) || state.settings.pollIntervalMs
+  );
+  const nextInterface = String(formData.get("interfaceMode") || "simulator");
+  const nextLogging = String(formData.get("logging") || "true") === "true";
+
+  state.settings.pollIntervalMs = nextInterval;
+  state.settings.interface = nextInterface;
+  state.settings.logging = nextLogging;
+
+  saveState("csh-settings", {
+    pollIntervalMs: nextInterval,
+    interface: nextInterface,
+    logging: nextLogging,
+  });
+
+  ensureLivePolling(nextInterval);
+  refreshLiveData();
+  render();
+}
+
+async function refreshLiveData() {
+  try {
+    const payload = await fetchJson("/api/live", 1200);
+    const live = normalizeLiveData(payload);
+    state.liveData = live;
+    state.api.backendReachable = true;
+    state.api.liveFailures = 0;
+    state.settings.pollIntervalMs = normalizeInterval(
+      live.read_interval_ms || state.settings.pollIntervalMs
+    );
+    state.settings.interface = live.mode || state.settings.interface;
+    ensureLivePolling(state.settings.pollIntervalMs);
+  } catch (_error) {
+    state.api.liveFailures += 1;
+    state.api.backendReachable = false;
+    state.liveData = generateSimulatedLiveData(state.liveData);
+  } finally {
+    state.lastLiveUpdate = Date.now();
+    render();
+  }
+}
+
+async function refreshRecordings() {
+  try {
+    const payload = await fetchJson("/api/recordings", 1200);
+    const recordings = normalizeRecordings(payload);
+    if (recordings.length) {
+      state.recordings = recordings;
+    } else if (!state.recordings.length) {
+      state.recordings = getFallbackRecordings();
+    }
+    state.api.recordingsFailures = 0;
+  } catch (_error) {
+    state.api.recordingsFailures += 1;
+    if (!state.recordings.length) {
+      state.recordings = getFallbackRecordings();
+    }
+  } finally {
+    render();
+  }
+}
+
+function startRecordingsPolling() {
+  if (state.timers.recordingsPollingId) {
+    clearInterval(state.timers.recordingsPollingId);
+  }
+  state.timers.recordingsPollingId = setInterval(refreshRecordings, 15000);
+}
+
+function ensureLivePolling(intervalMs) {
+  const normalized = normalizeInterval(intervalMs);
+  if (
+    state.timers.livePollingId &&
+    state.timers.activeLiveIntervalMs === normalized
+  ) {
+    return;
+  }
+  if (state.timers.livePollingId) {
+    clearInterval(state.timers.livePollingId);
+  }
+  state.timers.activeLiveIntervalMs = normalized;
+  state.timers.livePollingId = setInterval(refreshLiveData, normalized);
+}
+
+function toggleReplay() {
+  if (state.replay.playing) {
+    stopReplayTimer();
+    return;
+  }
+  if (!state.replay.selectedRecordingId) {
+    return;
+  }
+  state.replay.playing = true;
+  state.replay.timerId = setInterval(() => {
+    const next = state.replay.progressPercent + 1;
+    if (next >= 100) {
+      state.replay.progressPercent = 100;
+      stopReplayTimer();
+      saveState("csh-replay", {
+        selectedRecordingId: state.replay.selectedRecordingId,
+        progressPercent: 100,
+      });
+      render();
+      return;
+    }
+    state.replay.progressPercent = next;
+    saveState("csh-replay", {
+      selectedRecordingId: state.replay.selectedRecordingId,
+      progressPercent: next,
+    });
+    render();
+  }, 150);
+}
+
+function stopReplayTimer() {
+  if (state.replay.timerId) {
+    clearInterval(state.replay.timerId);
+    state.replay.timerId = null;
+  }
+  state.replay.playing = false;
+}
+
+function getReplaySeries(recordingId) {
+  if (state.replay.seriesCache[recordingId]) {
+    return state.replay.seriesCache[recordingId];
+  }
+  const series = Array.from({ length: 120 }, (_, index) => {
+    const rpm = Math.round(900 + Math.sin(index / 7) * 500 + randomInRange(-80, 80));
+    const temperature = Math.round(75 + Math.sin(index / 18) * 10 + randomInRange(-2, 2));
+    const fuel = Number((44 - index * 0.04 + randomInRange(-0.15, 0.15)).toFixed(1));
+    return {
+      rpm: clamp(rpm, 700, 3500),
+      temperature: clamp(temperature, 60, 120),
+      fuel_liters: clamp(fuel, 2, 55),
+    };
+  });
+  state.replay.seriesCache[recordingId] = series;
+  return series;
+}
+
+function exportRecording(recordingId) {
+  const recording = state.recordings.find((item) => item.id === recordingId);
+  if (!recording) {
+    return;
+  }
+
+  const payload = {
+    exported_at: new Date().toISOString(),
+    recording,
+    samples: getReplaySeries(recording.id),
+  };
+
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${recording.id}.json`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function fetchJson(url, timeoutMs) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "x-api-key": "csh-secure-v1",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function normalizeLiveData(payload) {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid /api/live payload");
+  }
+
+  const rpm = toNumber(payload.rpm);
+  const temperature = toNumber(payload.temperature ?? payload.motor_temp);
+  const fuelLiters = toNumber(
+    payload.fuel_liters ?? payload.fuel_l ?? payload.fuelLevelLiters
+  );
+  const connected =
+    typeof payload.connected === "boolean"
+      ? payload.connected
+      : String(payload.status || "").toLowerCase() === "connected";
+  const intervalMs = normalizeInterval(
+    toNumber(payload.read_interval_ms ?? payload.poll_interval_ms) ||
+      state.settings.pollIntervalMs
+  );
+  const mode = String(
+    payload.mode ?? payload.interface ?? (connected ? "hardware" : "simulator")
+  );
+
+  return {
+    rpm: rpm ?? 0,
+    temperature: temperature ?? 0,
+    fuel_liters: fuelLiters ?? 0,
+    connected,
+    read_interval_ms: intervalMs,
+    mode,
+  };
+}
+
+function normalizeRecordings(payload) {
+  const list = Array.isArray(payload) ? payload : payload?.recordings;
+  if (!Array.isArray(list)) return [];
+
+  return list
+    .map((item, index) => {
+      const id = String(item.id ?? `recording-${index + 1}`);
+      const name = String(item.name ?? `Recording ${index + 1}`);
+      const finishedAt = item.finished_at ?? item.finishedAt ?? new Date().toISOString();
+      const sizeBytes = Number(item.size_bytes ?? item.sizeBytes ?? 0);
+      return {
+        id,
+        name,
+        finished_at: finishedAt,
+        size_bytes: Number.isFinite(sizeBytes) ? sizeBytes : 0,
+      };
+    })
+    .filter((item) => item.id);
+}
+
+function getFallbackRecordings() {
+  return [
+    {
+      id: "demo-001",
+      name: "Morning City Drive",
+      finished_at: "2026-03-10T07:42:00Z",
+      size_bytes: 1_824_112,
+    },
+    {
+      id: "demo-002",
+      name: "Evening Country Road",
+      finished_at: "2026-03-09T18:13:00Z",
+      size_bytes: 2_906_345,
+    },
+    {
+      id: "demo-003",
+      name: "Workshop Test Run",
+      finished_at: "2026-03-08T11:05:00Z",
+      size_bytes: 965_440,
+    },
+  ];
+}
+
+function generateSimulatedLiveData(previousLiveData) {
+  const prev = previousLiveData || {
+    rpm: 900,
+    temperature: 78,
+    fuel_liters: 43,
+  };
+  return {
+    rpm: clamp(Math.round(prev.rpm + randomInRange(-120, 120)), 700, 3200),
+    temperature: clamp(
+      Math.round(prev.temperature + randomInRange(-1.5, 1.5)),
+      65,
+      108
+    ),
+    fuel_liters: clamp(
+      Number((prev.fuel_liters + randomInRange(-0.15, 0.1)).toFixed(1)),
+      1,
+      55
+    ),
+    connected: false,
+    read_interval_ms: state.settings.pollIntervalMs,
+    mode: "simulator",
+  };
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function normalizeInterval(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 1000;
+  return clamp(Math.round(number), 250, 10000);
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function randomInRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function formatNumber(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "\u2014";
+  return new Intl.NumberFormat("en", {
+    maximumFractionDigits: 0,
+  }).format(Number(value));
+}
+
+function formatDecimal(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "\u2014";
+  return new Intl.NumberFormat("en", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(Number(value));
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return "\u2014";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDateTime(value) {
+  if (!value) return "\u2014";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "\u2014";
+  return date.toLocaleString("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function formatMs(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "\u2014";
+  return `${Math.round(num)} ms`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,291 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #161b22;
+  --panel-alt: #1c2333;
+  --text: #c9d1d9;
+  --muted: #8b949e;
+  --border: #30363d;
+  --primary: #58a6ff;
+  --danger: #ff7b72;
+  --warning: #d29922;
+  --ok: #3fb950;
+  --shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.layout {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+}
+
+.sidebar {
+  background: #0c1222;
+  color: #f7f9ff;
+  padding: 1.25rem 1rem;
+  border-right: 1px solid #1c2536;
+}
+
+.sidebar h1 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #58a6ff;
+}
+
+.sidebar-subtitle {
+  margin: 0.25rem 0 1rem;
+  color: #8b949e;
+  font-size: 0.9rem;
+}
+
+.sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.sidebar nav a {
+  text-decoration: none;
+  color: #c9d1d9;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.55rem;
+  transition: background-color 120ms ease;
+}
+
+.sidebar nav a:hover,
+.sidebar nav a.active {
+  background: #1f3a6e;
+  color: #58a6ff;
+}
+
+.sidebar-note {
+  margin-top: 1rem;
+  font-size: 0.86rem;
+  color: #8b949e;
+  line-height: 1.4;
+  border: 1px solid #30363d;
+  border-radius: 0.6rem;
+  padding: 0.7rem;
+}
+
+.main {
+  padding: 1.5rem;
+}
+
+.page-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.page-header p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+.status-banner {
+  margin-top: 1rem;
+  border-radius: 0.8rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid transparent;
+  font-weight: 500;
+}
+
+.status-banner.ok {
+  background: rgba(63, 185, 80, 0.1);
+  color: var(--ok);
+  border-color: rgba(63, 185, 80, 0.3);
+}
+
+.status-banner.warning {
+  background: rgba(210, 153, 34, 0.1);
+  color: var(--warning);
+  border-color: rgba(210, 153, 34, 0.3);
+}
+
+.status-banner.error {
+  background: rgba(255, 123, 114, 0.1);
+  color: var(--danger);
+  border-color: rgba(255, 123, 114, 0.3);
+}
+
+.status-banner.waiting {
+  background: rgba(88, 166, 255, 0.1);
+  color: #58a6ff;
+  border-color: rgba(88, 166, 255, 0.3);
+}
+
+.view {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  box-shadow: var(--shadow);
+}
+
+.kpi-label {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.kpi-value {
+  margin: 0.45rem 0 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.subtle {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  overflow: hidden;
+}
+
+th,
+td {
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 0.9rem;
+  font-size: 0.95rem;
+}
+
+th {
+  background: var(--panel-alt);
+  color: var(--muted);
+  font-weight: 600;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+button,
+.button-link {
+  border: 1px solid #30363d;
+  background: #21262d;
+  color: #c9d1d9;
+  border-radius: 0.55rem;
+  padding: 0.5rem 0.7rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+button:hover {
+  background: #30363d;
+}
+
+button.primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #ffffff;
+}
+
+button.primary:hover {
+  background: #4090e0;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.92rem;
+}
+
+input,
+select {
+  border: 1px solid var(--border);
+  border-radius: 0.55rem;
+  padding: 0.5rem 0.65rem;
+  font: inherit;
+  background: #0d1117;
+  color: var(--text);
+}
+
+.progress {
+  width: 100%;
+  height: 10px;
+  background: #21262d;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress > div {
+  height: 100%;
+  background: var(--primary);
+  width: 0%;
+  transition: width 100ms linear;
+}
+
+.empty-state {
+  border: 1px dashed #30363d;
+  border-radius: 0.75rem;
+  padding: 1.1rem;
+  color: var(--muted);
+  background: #161b22;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid #1c2536;
+  }
+
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.2.1"
+      },
+      "bin": {
+        "adm": "cli/adm.js"
       }
     },
     "node_modules/accepts": {

--- a/tims/Features/cli.md
+++ b/tims/Features/cli.md
@@ -1,0 +1,101 @@
+# CLI Feature (<span style="color:#ff0000;">Tim</span> + <span style="color:#ff69b4;">Jana</span>)
+
+High-level plan for the CLI that launches the local webapp and backend.
+
+---
+
+## 1. Goals
+
+- Provide a single command to start everything needed:
+  - Backend server.
+  - Dashboard webapp.
+- Clean up any **old/stuck temporary data** on startup if needed.
+- Make it obvious when the system is **ready** or when something is wrong.
+
+---
+
+## 2. Command Name & Aliases
+
+- Main command: `csh-auto-data-machine`
+- Short alias: `adm`
+
+Example:
+
+```bash
+adm --interface simulator
+```
+
+---
+
+## 3. Flags / Options (v1)
+
+- `--port <number>`
+  - Port for the dashboard/backend (default e.g. `3000`).
+
+- `--poll-interval-ms <number>`
+  - Polling interval in milliseconds (default safe value, e.g. `1000`).
+
+- `--interface <simulator|hardware>`
+  - Whether to use simulated data or the real hardware adapter.
+
+- `--data-dir <path>`
+  - Directory where recordings and logs are stored.
+
+- `--log-level <error|info|debug>`
+  - Controls verbosity of logs.
+
+These flags give you “as much as possible” control without being overwhelming.
+
+---
+
+## 4. Startup Behavior
+
+On startup the CLI should:
+
+1. Optionally clean old temporary or stuck state (e.g. temp files).
+2. Start the backend process (with the chosen flags).
+3. Start or open the dashboard in the browser.
+4. Run **two tests**:
+   - CLI → Backend (`GET /api/status`).
+   - Backend confirms bus adapter/simulator is OK.
+5. Only then print a clear **READY** message with:
+   - Dashboard URL.
+   - Current interface (simulator/hardware).
+   - Current polling interval and data directory.
+
+---
+
+## 5. Shutdown Behavior
+
+- **Emergency:** `Ctrl+C` immediately stops CLI and attempts to stop child processes.
+- **Normal shutdown:** provide an explicit option (e.g. `adm stop`) or a button in the dashboard that calls a shutdown endpoint.
+- Before shutdown:
+  - Flush any remaining buffers.
+  - Write a final log entry indicating clean stop.
+
+---
+
+## 6. Tasks for CLI
+
+### <span style="color:#ff0000;">Tim</span> (UX / messages)
+
+- [ ] Design the text of startup and error messages so they are easy to understand.
+- [ ] Decide how to present URLs and current configuration after startup.
+- [ ] Plan the layout/content of any CLI help output (`adm --help`).
+
+### <span style="color:#ff69b4;">Jana</span> (Process & checks)
+
+- [ ] Define how the CLI spawns backend and frontend processes.
+- [ ] Specify the `/api/status` contract used for health checks.
+- [ ] Describe how the CLI detects failures and exits with appropriate codes.
+- [ ] Plan how cleanup of old/stuck data works on startup.
+
+---
+
+#### Navigation
+
+- [Home](../README.md)
+- [Client spec](../Spec/Client/readme.md)
+- [Routes spec](../Spec/Routes/readme.md)
+- [Backend spec](../Spec/Backend/server.md)
+- [Tasks: CLI](../Tasks/cli.md)

--- a/tims/client/app.js
+++ b/tims/client/app.js
@@ -1,0 +1,739 @@
+const pageTitleEl = document.querySelector("#page-title");
+const pageSubtitleEl = document.querySelector("#page-subtitle");
+const statusBannerEl = document.querySelector("#status-banner");
+const viewEl = document.querySelector("#view");
+
+const PAGE_META = {
+  "/": {
+    title: "Dashboard",
+    subtitle: "Live-Werte, Verbindungsstatus und Polling-Intervall",
+  },
+  "/recordings": {
+    title: "Aufnahmen",
+    subtitle: "Gespeicherte Sessions mit Metadaten",
+  },
+  "/recordings/:id": {
+    title: "Replay",
+    subtitle: "Aufnahme ansehen und Wiederholung steuern",
+  },
+  "/settings": {
+    title: "Settings",
+    subtitle: "Polling, Interface und Logging verwalten",
+  },
+};
+
+const state = {
+  route: { path: "/", params: {} },
+  api: {
+    backendReachable: null,
+    liveFailures: 0,
+    recordingsFailures: 0,
+  },
+  liveData: null,
+  recordings: [],
+  lastLiveUpdate: null,
+  settings: {
+    pollIntervalMs: 1000,
+    interface: "simulator",
+    logging: true,
+  },
+  replay: {
+    selectedRecordingId: null,
+    playing: false,
+    progressPercent: 0,
+    timerId: null,
+    seriesCache: {},
+  },
+  timers: {
+    livePollingId: null,
+    recordingsPollingId: null,
+    activeLiveIntervalMs: null,
+  },
+};
+
+window.addEventListener("hashchange", onRouteChange);
+viewEl.addEventListener("click", onViewClick);
+viewEl.addEventListener("submit", onViewSubmit);
+
+init();
+
+function init() {
+  if (!window.location.hash) {
+    window.location.hash = "#/";
+  }
+  onRouteChange();
+  refreshLiveData();
+  refreshRecordings();
+  ensureLivePolling(state.settings.pollIntervalMs);
+  startRecordingsPolling();
+}
+
+function onRouteChange() {
+  state.route = parseRoute(window.location.hash);
+  if (state.route.path !== "/recordings/:id") {
+    stopReplayTimer();
+  } else {
+    state.replay.selectedRecordingId = state.route.params.id;
+  }
+  render();
+}
+
+function parseRoute(hashValue) {
+  const hashWithoutMarker = (hashValue || "#/").replace(/^#/, "") || "/";
+  const [path] = hashWithoutMarker.split("?");
+  if (path === "/" || path === "") return { path: "/", params: {} };
+  if (path === "/recordings") return { path: "/recordings", params: {} };
+  if (path.startsWith("/recordings/")) {
+    const id = decodeURIComponent(path.split("/")[2] || "");
+    return { path: "/recordings/:id", params: { id } };
+  }
+  if (path === "/settings") return { path: "/settings", params: {} };
+  return { path: "/", params: {} };
+}
+
+function render() {
+  const meta = PAGE_META[state.route.path] || PAGE_META["/"];
+  pageTitleEl.textContent = meta.title;
+  pageSubtitleEl.textContent = meta.subtitle;
+  highlightActiveNav();
+  renderStatusBanner();
+  renderRouteContent();
+}
+
+function highlightActiveNav() {
+  const navLinks = document.querySelectorAll("[data-nav]");
+  navLinks.forEach((link) => {
+    const linkRoute = link.getAttribute("data-nav");
+    const isActive =
+      linkRoute === state.route.path ||
+      (linkRoute === "/recordings/:id" && state.route.path === "/recordings/:id");
+    link.classList.toggle("active", isActive);
+  });
+}
+
+function renderStatusBanner() {
+  const banner = resolveBannerData();
+  statusBannerEl.className = `status-banner ${banner.kind}`;
+  statusBannerEl.textContent = banner.message;
+}
+
+function resolveBannerData() {
+  if (!state.liveData && state.api.backendReachable === null) {
+    return { kind: "waiting", message: "Warte auf erste Daten vom Backend …" };
+  }
+  if (state.api.backendReachable === false) {
+    return {
+      kind: "warning",
+      message:
+        "Backend nicht erreichbar – der Client zeigt simulierte Daten an.",
+    };
+  }
+  if (!state.liveData) {
+    return {
+      kind: "error",
+      message: "Keine Live-Daten verfügbar.",
+    };
+  }
+  if (state.liveData.connected) {
+    return {
+      kind: "ok",
+      message: `Verbunden (${state.liveData.mode || "hardware"}) · Polling ${formatMs(
+        state.liveData.read_interval_ms
+      )}`,
+    };
+  }
+  return {
+    kind: "warning",
+    message: `Keine Fahrzeugverbindung · Modus ${state.liveData.mode || "simulator"} · Polling ${formatMs(
+      state.liveData.read_interval_ms
+    )}`,
+  };
+}
+
+function renderRouteContent() {
+  if (state.route.path === "/") {
+    viewEl.innerHTML = renderDashboardView();
+    return;
+  }
+  if (state.route.path === "/recordings") {
+    viewEl.innerHTML = renderRecordingsView();
+    return;
+  }
+  if (state.route.path === "/recordings/:id") {
+    viewEl.innerHTML = renderReplayView(state.route.params.id);
+    return;
+  }
+  if (state.route.path === "/settings") {
+    viewEl.innerHTML = renderSettingsView();
+    return;
+  }
+  viewEl.innerHTML = "";
+}
+
+function renderDashboardView() {
+  const live = state.liveData || {};
+  const connectionLabel = state.api.backendReachable
+    ? live.connected
+      ? "Connected"
+      : "Disconnected"
+    : "Simulation";
+
+  return `
+    <section class="grid-3">
+      <article class="card">
+        <p class="kpi-label">Motor RPM</p>
+        <p class="kpi-value">${formatNumber(live.rpm)}</p>
+        <p class="subtle">U/min</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Motor Temperatur</p>
+        <p class="kpi-value">${formatNumber(live.temperature)}</p>
+        <p class="subtle">°C</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Fuel Level</p>
+        <p class="kpi-value">${formatDecimal(live.fuel_liters)}</p>
+        <p class="subtle">Liter</p>
+      </article>
+    </section>
+    <article class="card">
+      <p class="kpi-label">Status</p>
+      <p class="kpi-value">${escapeHtml(connectionLabel)}</p>
+      <p class="subtle">
+        Letztes Update: ${formatDateTime(state.lastLiveUpdate)} ·
+        Polling: ${formatMs(live.read_interval_ms || state.settings.pollIntervalMs)}
+      </p>
+    </article>
+  `;
+}
+
+function renderRecordingsView() {
+  if (!state.recordings.length) {
+    return `
+      <article class="empty-state">
+        Noch keine Aufnahmen gefunden.
+      </article>
+    `;
+  }
+
+  const rows = state.recordings
+    .map(
+      (recording) => `
+      <tr>
+        <td>${escapeHtml(recording.name)}</td>
+        <td>${formatDateTime(recording.finished_at)}</td>
+        <td>${formatBytes(recording.size_bytes)}</td>
+        <td class="button-row">
+          <button data-action="open-recording" data-recording-id="${escapeHtml(
+            recording.id
+          )}">Öffnen</button>
+          <button data-action="export-recording" data-recording-id="${escapeHtml(
+            recording.id
+          )}">Export JSON</button>
+        </td>
+      </tr>
+    `
+    )
+    .join("");
+
+  return `
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Beendet</th>
+            <th>Größe</th>
+            <th>Aktion</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderReplayView(recordingId) {
+  const recording = state.recordings.find((item) => item.id === recordingId);
+  if (!recording) {
+    return `
+      <article class="empty-state">
+        Aufnahme nicht gefunden. Bitte zuerst in der Aufnahmen-Liste auswählen.
+      </article>
+      <div class="button-row">
+        <button data-action="go-recordings">Zurück zur Liste</button>
+      </div>
+    `;
+  }
+
+  const points = getReplaySeries(recording.id);
+  const index = Math.min(
+    points.length - 1,
+    Math.floor((state.replay.progressPercent / 100) * (points.length - 1))
+  );
+  const currentPoint = points[index] || {};
+
+  return `
+    <article class="card">
+      <p class="kpi-label">Aufnahme</p>
+      <p class="kpi-value">${escapeHtml(recording.name)}</p>
+      <p class="subtle">
+        ${formatDateTime(recording.finished_at)} · ${formatBytes(recording.size_bytes)}
+      </p>
+    </article>
+    <article class="card">
+      <p class="kpi-label">Replay Fortschritt</p>
+      <div class="progress">
+        <div style="width: ${state.replay.progressPercent}%"></div>
+      </div>
+      <p class="subtle">${state.replay.progressPercent.toFixed(0)}%</p>
+      <div class="button-row">
+        <button class="primary" data-action="toggle-replay">
+          ${state.replay.playing ? "Pause" : "Play"}
+        </button>
+        <button data-action="reset-replay">Reset</button>
+        <button data-action="go-recordings">Zur Liste</button>
+      </div>
+    </article>
+    <section class="grid-3">
+      <article class="card">
+        <p class="kpi-label">Replay RPM</p>
+        <p class="kpi-value">${formatNumber(currentPoint.rpm)}</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Replay Temperatur</p>
+        <p class="kpi-value">${formatNumber(currentPoint.temperature)} °C</p>
+      </article>
+      <article class="card">
+        <p class="kpi-label">Replay Fuel</p>
+        <p class="kpi-value">${formatDecimal(currentPoint.fuel_liters)} L</p>
+      </article>
+    </section>
+  `;
+}
+
+function renderSettingsView() {
+  return `
+    <article class="card">
+      <form id="settings-form" class="form-grid">
+        <label>
+          Polling-Intervall (ms)
+          <input name="pollIntervalMs" type="number" min="250" max="10000" step="50" value="${state.settings.pollIntervalMs}" />
+        </label>
+        <label>
+          Interface
+          <select name="interfaceMode">
+            <option value="simulator" ${
+              state.settings.interface === "simulator" ? "selected" : ""
+            }>simulator</option>
+            <option value="hardware" ${
+              state.settings.interface === "hardware" ? "selected" : ""
+            }>hardware</option>
+          </select>
+        </label>
+        <label>
+          Logging
+          <select name="logging">
+            <option value="true" ${state.settings.logging ? "selected" : ""}>enabled</option>
+            <option value="false" ${!state.settings.logging ? "selected" : ""}>disabled</option>
+          </select>
+        </label>
+        <div class="button-row">
+          <button class="primary" type="submit">Settings anwenden</button>
+          <button type="button" data-action="refresh-now">Daten jetzt aktualisieren</button>
+        </div>
+      </form>
+      <p class="subtle">
+        Der Client verwendet bevorzugt: <code>GET /api/live</code> und <code>GET /api/recordings</code>.
+        Falls diese Endpunkte fehlen, wird automatisch auf Simulation umgestellt.
+      </p>
+    </article>
+  `;
+}
+
+function onViewClick(event) {
+  const target = event.target.closest("[data-action]");
+  if (!target) return;
+  const action = target.getAttribute("data-action");
+
+  if (action === "open-recording") {
+    const recordingId = target.getAttribute("data-recording-id");
+    if (recordingId) {
+      window.location.hash = `#/recordings/${encodeURIComponent(recordingId)}`;
+    }
+    return;
+  }
+
+  if (action === "export-recording") {
+    const recordingId = target.getAttribute("data-recording-id");
+    if (recordingId) {
+      exportRecording(recordingId);
+    }
+    return;
+  }
+
+  if (action === "toggle-replay") {
+    toggleReplay();
+    render();
+    return;
+  }
+
+  if (action === "reset-replay") {
+    stopReplayTimer();
+    state.replay.progressPercent = 0;
+    render();
+    return;
+  }
+
+  if (action === "go-recordings") {
+    window.location.hash = "#/recordings";
+    return;
+  }
+
+  if (action === "refresh-now") {
+    refreshLiveData();
+    refreshRecordings();
+  }
+}
+
+function onViewSubmit(event) {
+  const form = event.target;
+  if (!(form instanceof HTMLFormElement)) return;
+  if (form.id !== "settings-form") return;
+
+  event.preventDefault();
+  const formData = new FormData(form);
+
+  const nextInterval = normalizeInterval(
+    Number(formData.get("pollIntervalMs")) || state.settings.pollIntervalMs
+  );
+  const nextInterface = String(formData.get("interfaceMode") || "simulator");
+  const nextLogging = String(formData.get("logging") || "true") === "true";
+
+  state.settings.pollIntervalMs = nextInterval;
+  state.settings.interface = nextInterface;
+  state.settings.logging = nextLogging;
+  ensureLivePolling(nextInterval);
+  refreshLiveData();
+  render();
+}
+
+async function refreshLiveData() {
+  try {
+    const payload = await fetchJson("/api/live", 1200);
+    const live = normalizeLiveData(payload);
+    state.liveData = live;
+    state.api.backendReachable = true;
+    state.api.liveFailures = 0;
+    state.settings.pollIntervalMs = normalizeInterval(
+      live.read_interval_ms || state.settings.pollIntervalMs
+    );
+    state.settings.interface = live.mode || state.settings.interface;
+    ensureLivePolling(state.settings.pollIntervalMs);
+  } catch (_error) {
+    state.api.liveFailures += 1;
+    state.api.backendReachable = false;
+    state.liveData = generateSimulatedLiveData(state.liveData);
+  } finally {
+    state.lastLiveUpdate = Date.now();
+    render();
+  }
+}
+
+async function refreshRecordings() {
+  try {
+    const payload = await fetchJson("/api/recordings", 1200);
+    const recordings = normalizeRecordings(payload);
+    if (recordings.length) {
+      state.recordings = recordings;
+    } else if (!state.recordings.length) {
+      state.recordings = getFallbackRecordings();
+    }
+    state.api.recordingsFailures = 0;
+  } catch (_error) {
+    state.api.recordingsFailures += 1;
+    if (!state.recordings.length) {
+      state.recordings = getFallbackRecordings();
+    }
+  } finally {
+    render();
+  }
+}
+
+function startRecordingsPolling() {
+  if (state.timers.recordingsPollingId) {
+    clearInterval(state.timers.recordingsPollingId);
+  }
+  state.timers.recordingsPollingId = setInterval(refreshRecordings, 15000);
+}
+
+function ensureLivePolling(intervalMs) {
+  const normalized = normalizeInterval(intervalMs);
+  if (
+    state.timers.livePollingId &&
+    state.timers.activeLiveIntervalMs === normalized
+  ) {
+    return;
+  }
+  if (state.timers.livePollingId) {
+    clearInterval(state.timers.livePollingId);
+  }
+  state.timers.activeLiveIntervalMs = normalized;
+  state.timers.livePollingId = setInterval(refreshLiveData, normalized);
+}
+
+function toggleReplay() {
+  if (state.replay.playing) {
+    stopReplayTimer();
+    return;
+  }
+  if (!state.replay.selectedRecordingId) {
+    return;
+  }
+  state.replay.playing = true;
+  state.replay.timerId = setInterval(() => {
+    const next = state.replay.progressPercent + 1;
+    if (next >= 100) {
+      state.replay.progressPercent = 100;
+      stopReplayTimer();
+      render();
+      return;
+    }
+    state.replay.progressPercent = next;
+    render();
+  }, 150);
+}
+
+function stopReplayTimer() {
+  if (state.replay.timerId) {
+    clearInterval(state.replay.timerId);
+    state.replay.timerId = null;
+  }
+  state.replay.playing = false;
+}
+
+function getReplaySeries(recordingId) {
+  if (state.replay.seriesCache[recordingId]) {
+    return state.replay.seriesCache[recordingId];
+  }
+  const series = Array.from({ length: 120 }, (_, index) => {
+    const rpm = Math.round(900 + Math.sin(index / 7) * 500 + randomInRange(-80, 80));
+    const temperature = Math.round(75 + Math.sin(index / 18) * 10 + randomInRange(-2, 2));
+    const fuel = Number((44 - index * 0.04 + randomInRange(-0.15, 0.15)).toFixed(1));
+    return {
+      rpm: clamp(rpm, 700, 3500),
+      temperature: clamp(temperature, 60, 120),
+      fuel_liters: clamp(fuel, 2, 55),
+    };
+  });
+  state.replay.seriesCache[recordingId] = series;
+  return series;
+}
+
+function exportRecording(recordingId) {
+  const recording = state.recordings.find((item) => item.id === recordingId);
+  if (!recording) {
+    return;
+  }
+
+  const payload = {
+    exported_at: new Date().toISOString(),
+    recording,
+    samples: getReplaySeries(recording.id),
+  };
+
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${recording.id}.json`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function fetchJson(url, timeoutMs) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function normalizeLiveData(payload) {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid /api/live payload");
+  }
+
+  const rpm = toNumber(payload.rpm);
+  const temperature = toNumber(payload.temperature ?? payload.motor_temp);
+  const fuelLiters = toNumber(
+    payload.fuel_liters ?? payload.fuel_l ?? payload.fuelLevelLiters
+  );
+  const connected =
+    typeof payload.connected === "boolean"
+      ? payload.connected
+      : String(payload.status || "").toLowerCase() === "connected";
+  const intervalMs = normalizeInterval(
+    toNumber(payload.read_interval_ms ?? payload.poll_interval_ms) ||
+      state.settings.pollIntervalMs
+  );
+  const mode = String(
+    payload.mode ?? payload.interface ?? (connected ? "hardware" : "simulator")
+  );
+
+  return {
+    rpm: rpm ?? 0,
+    temperature: temperature ?? 0,
+    fuel_liters: fuelLiters ?? 0,
+    connected,
+    read_interval_ms: intervalMs,
+    mode,
+  };
+}
+
+function normalizeRecordings(payload) {
+  const list = Array.isArray(payload) ? payload : payload?.recordings;
+  if (!Array.isArray(list)) return [];
+
+  return list
+    .map((item, index) => {
+      const id = String(item.id ?? `recording-${index + 1}`);
+      const name = String(item.name ?? `Recording ${index + 1}`);
+      const finishedAt = item.finished_at ?? item.finishedAt ?? new Date().toISOString();
+      const sizeBytes = Number(item.size_bytes ?? item.sizeBytes ?? 0);
+      return {
+        id,
+        name,
+        finished_at: finishedAt,
+        size_bytes: Number.isFinite(sizeBytes) ? sizeBytes : 0,
+      };
+    })
+    .filter((item) => item.id);
+}
+
+function getFallbackRecordings() {
+  return [
+    {
+      id: "demo-001",
+      name: "Stadtfahrt Morgen",
+      finished_at: "2026-03-10T07:42:00Z",
+      size_bytes: 1_824_112,
+    },
+    {
+      id: "demo-002",
+      name: "Landstraße Abend",
+      finished_at: "2026-03-09T18:13:00Z",
+      size_bytes: 2_906_345,
+    },
+    {
+      id: "demo-003",
+      name: "Werkstatt Testlauf",
+      finished_at: "2026-03-08T11:05:00Z",
+      size_bytes: 965_440,
+    },
+  ];
+}
+
+function generateSimulatedLiveData(previousLiveData) {
+  const prev = previousLiveData || {
+    rpm: 900,
+    temperature: 78,
+    fuel_liters: 43,
+  };
+  return {
+    rpm: clamp(Math.round(prev.rpm + randomInRange(-120, 120)), 700, 3200),
+    temperature: clamp(
+      Math.round(prev.temperature + randomInRange(-1.5, 1.5)),
+      65,
+      108
+    ),
+    fuel_liters: clamp(
+      Number((prev.fuel_liters + randomInRange(-0.15, 0.1)).toFixed(1)),
+      1,
+      55
+    ),
+    connected: false,
+    read_interval_ms: state.settings.pollIntervalMs,
+    mode: "simulator",
+  };
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function normalizeInterval(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 1000;
+  return clamp(Math.round(number), 250, 10000);
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function randomInRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function formatNumber(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  return new Intl.NumberFormat("de-DE", {
+    maximumFractionDigits: 0,
+  }).format(Number(value));
+}
+
+function formatDecimal(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  return new Intl.NumberFormat("de-DE", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(Number(value));
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDateTime(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("de-DE", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function formatMs(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "—";
+  return `${Math.round(num)} ms`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/tims/client/index.html
+++ b/tims/client/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -10,21 +10,21 @@
     <div class="layout">
       <aside class="sidebar">
         <h1>CSH Auto Data</h1>
-        <p class="sidebar-subtitle">Local Dashboard Client</p>
+        <p class="sidebar-subtitle">Lokaler Dashboard-Client</p>
         <nav>
           <a href="#/" data-nav="/">Dashboard</a>
-          <a href="#/recordings" data-nav="/recordings">Recordings</a>
+          <a href="#/recordings" data-nav="/recordings">Aufnahmen</a>
           <a href="#/recordings/demo-001" data-nav="/recordings/:id">Replay</a>
           <a href="#/settings" data-nav="/settings">Settings</a>
         </nav>
         <div class="sidebar-note">
-          <strong>Note:</strong> If no backend is reachable, the client automatically uses simulated data.
+          <strong>Hinweis:</strong> Wenn kein Backend erreichbar ist, nutzt der Client automatisch simulierte Daten.
         </div>
       </aside>
       <main class="main">
         <header class="page-header">
           <h2 id="page-title">Dashboard</h2>
-          <p id="page-subtitle">Live values, connection status and polling interval</p>
+          <p id="page-subtitle">Live-Werte, Verbindungsstatus und Polling-Intervall</p>
         </header>
         <section id="status-banner" class="status-banner waiting"></section>
         <section id="view" class="view"></section>

--- a/tims/client/styles.css
+++ b/tims/client/styles.css
@@ -1,0 +1,279 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f6fb;
+  --panel: #ffffff;
+  --panel-alt: #f8f9fc;
+  --text: #101727;
+  --muted: #59657f;
+  --border: #d7deea;
+  --primary: #2f6fec;
+  --danger: #c92a2a;
+  --warning: #a85f00;
+  --ok: #17764c;
+  --shadow: 0 8px 30px rgba(16, 23, 39, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.layout {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+}
+
+.sidebar {
+  background: #0f182d;
+  color: #f7f9ff;
+  padding: 1.25rem 1rem;
+  border-right: 1px solid #26304d;
+}
+
+.sidebar h1 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.sidebar-subtitle {
+  margin: 0.25rem 0 1rem;
+  color: #b7c2de;
+  font-size: 0.9rem;
+}
+
+.sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.sidebar nav a {
+  text-decoration: none;
+  color: #dce6ff;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.55rem;
+  transition: background-color 120ms ease;
+}
+
+.sidebar nav a:hover,
+.sidebar nav a.active {
+  background: #2b4ea7;
+}
+
+.sidebar-note {
+  margin-top: 1rem;
+  font-size: 0.86rem;
+  color: #c9d5f5;
+  line-height: 1.4;
+  border: 1px solid #30416e;
+  border-radius: 0.6rem;
+  padding: 0.7rem;
+}
+
+.main {
+  padding: 1.5rem;
+}
+
+.page-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.page-header p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+.status-banner {
+  margin-top: 1rem;
+  border-radius: 0.8rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid transparent;
+  font-weight: 500;
+}
+
+.status-banner.ok {
+  background: #eaf8f1;
+  color: var(--ok);
+  border-color: #b8e7cd;
+}
+
+.status-banner.warning {
+  background: #fff6e7;
+  color: var(--warning);
+  border-color: #f3d7a9;
+}
+
+.status-banner.error {
+  background: #ffecec;
+  color: var(--danger);
+  border-color: #f5c5c5;
+}
+
+.status-banner.waiting {
+  background: #edf3ff;
+  color: #2d4e96;
+  border-color: #c7d7fa;
+}
+
+.view {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  box-shadow: var(--shadow);
+}
+
+.kpi-label {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.kpi-value {
+  margin: 0.45rem 0 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.subtle {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  overflow: hidden;
+}
+
+th,
+td {
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 0.9rem;
+  font-size: 0.95rem;
+}
+
+th {
+  background: var(--panel-alt);
+  color: var(--muted);
+  font-weight: 600;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+button,
+.button-link {
+  border: 1px solid #c1d2ff;
+  background: #f2f6ff;
+  color: #1f4aa5;
+  border-radius: 0.55rem;
+  padding: 0.5rem 0.7rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+button.primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #ffffff;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.92rem;
+}
+
+input,
+select {
+  border: 1px solid var(--border);
+  border-radius: 0.55rem;
+  padding: 0.5rem 0.65rem;
+  font: inherit;
+  background: #ffffff;
+}
+
+.progress {
+  width: 100%;
+  height: 10px;
+  background: #e7ecfa;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress > div {
+  height: 100%;
+  background: var(--primary);
+  width: 0%;
+  transition: width 100ms linear;
+}
+
+.empty-state {
+  border: 1px dashed #b9c6e4;
+  border-radius: 0.75rem;
+  padding: 1.1rem;
+  color: var(--muted);
+  background: #fafcff;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid #26304d;
+  }
+
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Claude max for all of us?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes backend API responses and adds an `x-api-key` gate on all `/api/*` routes, which can break existing clients if headers/payload expectations differ.
> 
> **Overview**
> Introduces a new single-page dashboard client (hash-based routing) with **Dashboard**, **Recordings**, **Replay**, and **Settings** views, including local persistence of settings/route, adjustable live polling, replay simulation, and JSON export of recordings.
> 
> Updates the Express backend to **serve the client statically**, enforce an `x-api-key` on `/api/*`, replace the old mock contract with a smoother simulator state (adds `temperature`, `fuel_liters`, `speed_kmh`, timestamps), and adds a new `GET /api/recordings` endpoint (currently empty). Also adds a CLI planning doc and a duplicated German-themed client under `tims/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 007178676143257c30de31e90f7d27118241dfa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->